### PR TITLE
feat/mypage : 마이페이지 사용자 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/shcho/myBlog/common/config/SecurityConfig.java
+++ b/src/main/java/com/shcho/myBlog/common/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.shcho.myBlog.common.config;
 
+import com.shcho.myBlog.common.util.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -9,10 +11,13 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+@RequiredArgsConstructor
 @Configuration
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -20,11 +25,11 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                new AntPathRequestMatcher("/api/auth/**")
-                        ).permitAll()
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/mypage").authenticated()
                         .anyRequest().authenticated()
-                );
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/shcho/myBlog/common/config/SecurityConfig.java
+++ b/src/main/java/com/shcho/myBlog/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.shcho.myBlog.common.config;
 
 import com.shcho.myBlog.common.util.JwtAuthenticationFilter;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,6 +30,12 @@ public class SecurityConfig {
                         .requestMatchers("/api/mypage").authenticated()
                         .anyRequest().authenticated()
                 )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.setContentType("application/json;charset=utf-8");
+                            response.getWriter().write("{\"message\": \"인증이 필요합니다.\"}");
+                        }))
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/shcho/myBlog/common/util/JwtAuthenticationFilter.java
+++ b/src/main/java/com/shcho/myBlog/common/util/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package com.shcho.myBlog.common.util;
+
+import com.shcho.myBlog.user.service.CustomUserDetailService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final CustomUserDetailService customUserDetailService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authHeader.substring(7);
+
+        if (!jwtProvider.validateToken(token)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String username = jwtProvider.getUsername(token);
+        UserDetails userDetails = customUserDetailService.loadUserByUsername(username);
+
+        UsernamePasswordAuthenticationToken authToken =
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+        authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/shcho/myBlog/mypage/controller/MyPageController.java
+++ b/src/main/java/com/shcho/myBlog/mypage/controller/MyPageController.java
@@ -1,0 +1,27 @@
+package com.shcho.myBlog.mypage.controller;
+
+import com.shcho.myBlog.mypage.dto.GetMyPageResponseDto;
+import com.shcho.myBlog.mypage.service.MyPageService;
+import com.shcho.myBlog.user.service.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/mypage")
+@RequiredArgsConstructor
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    @GetMapping
+    public ResponseEntity<GetMyPageResponseDto> getMyPage(
+            @AuthenticationPrincipal CustomUserDetails userDetail
+    ) {
+        Long userId = userDetail.getUserId();
+        return ResponseEntity.ok(myPageService.getMyPage(userId));
+    }
+}

--- a/src/main/java/com/shcho/myBlog/mypage/dto/GetMyPageResponseDto.java
+++ b/src/main/java/com/shcho/myBlog/mypage/dto/GetMyPageResponseDto.java
@@ -1,0 +1,20 @@
+package com.shcho.myBlog.mypage.dto;
+
+import com.shcho.myBlog.user.entity.Role;
+import com.shcho.myBlog.user.entity.User;
+import lombok.Builder;
+
+@Builder
+public record GetMyPageResponseDto(
+        String username,
+        String nickname,
+        Role role
+) {
+    public static GetMyPageResponseDto from(User user) {
+        return GetMyPageResponseDto.builder()
+                .username(user.getUsername())
+                .nickname(user.getNickname())
+                .role(user.getRole())
+                .build();
+    }
+}

--- a/src/main/java/com/shcho/myBlog/mypage/service/MyPageService.java
+++ b/src/main/java/com/shcho/myBlog/mypage/service/MyPageService.java
@@ -1,0 +1,19 @@
+package com.shcho.myBlog.mypage.service;
+
+import com.shcho.myBlog.mypage.dto.GetMyPageResponseDto;
+import com.shcho.myBlog.user.entity.User;
+import com.shcho.myBlog.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final UserRepository userRepository;
+
+    public GetMyPageResponseDto getMyPage(Long userId) {
+        User user = userRepository.getReferenceById(userId);
+        return GetMyPageResponseDto.from(user);
+    }
+}

--- a/src/main/java/com/shcho/myBlog/user/service/CustomUserDetailService.java
+++ b/src/main/java/com/shcho/myBlog/user/service/CustomUserDetailService.java
@@ -22,10 +22,6 @@ public class CustomUserDetailService implements UserDetailsService {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
-        return org.springframework.security.core.userdetails.User.builder()
-                .username(user.getUsername())
-                .password(user.getPassword())
-                .roles(String.valueOf(user.getRole()))
-                .build();
+        return new CustomUserDetails(user);
     }
 }

--- a/src/main/java/com/shcho/myBlog/user/service/CustomUserDetails.java
+++ b/src/main/java/com/shcho/myBlog/user/service/CustomUserDetails.java
@@ -1,0 +1,39 @@
+package com.shcho.myBlog.user.service;
+
+import com.shcho.myBlog.user.entity.Role;
+import com.shcho.myBlog.user.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final Long userId;
+    private final String username;
+    private final String password;
+    private final Role role;
+
+    public CustomUserDetails(User user) {
+        this.userId = user.getId();
+        this.username = user.getUsername();
+        this.password = user.getPassword();
+        this.role = user.getRole();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton((GrantedAuthority) () -> "ROLE_" + role.name());
+    }
+
+    @Override public String getPassword() { return password; }
+    @Override public String getUsername() { return username; }
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/shcho/myBlog/user/service/CustomUserDetails.java
+++ b/src/main/java/com/shcho/myBlog/user/service/CustomUserDetails.java
@@ -3,7 +3,6 @@ package com.shcho.myBlog.user.service;
 import com.shcho.myBlog.user.entity.Role;
 import com.shcho.myBlog.user.entity.User;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -30,10 +29,33 @@ public class CustomUserDetails implements UserDetails {
         return Collections.singleton((GrantedAuthority) () -> "ROLE_" + role.name());
     }
 
-    @Override public String getPassword() { return password; }
-    @Override public String getUsername() { return username; }
-    @Override public boolean isAccountNonExpired() { return true; }
-    @Override public boolean isAccountNonLocked() { return true; }
-    @Override public boolean isCredentialsNonExpired() { return true; }
-    @Override public boolean isEnabled() { return true; }
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 }


### PR DESCRIPTION
## 🔀 PR 제목
feat/mypage : 마이페이지 사용자 정보 조회 API 구현

## ✅ 작업 내용
- 마이페이지 기능의 첫 단계로, 현재 로그인된 사용자의 정보를 반환하는 API 구현
- JWT 인증 필터 적용 및 인증된 사용자만 접근 가능하도록 Security 설정 구성

### 구현 상세
- [x] GetMyPageResponse DTO 생성 (username, nickname, role)
- [x] MyPageService.getMyPage(userId) 구현
- [x] MyPageController에 `/api/mypage` GET API 추가
- [x] CustomUserDetails에서 userId 추출 가능하도록 변경
- [x] JwtAuthenticationFilter에서 SecurityContextHolder 설정 누락 수정
- [x] SecurityConfig에 인증 필터 추가 및 경로 보호 설정

## 🔧 변경사항
- `GetMyPageResponse.java`
- `MyPageService.java`
- `MyPageController.java`
- `CustomUserDetails.java`
- `CustomUserDetailService.java`
- `JwtAuthenticationFilter.java`
- `SecurityConfig.java`

## 📌 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요 -->
- close #8 
