### PR TITLE
Feat/mypage update nickname

### DIFF
--- a/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     /* 400 */
     USER_ALREADY_EXISTS(400, "이미 존재하는 사용자 입니다."),
     NICKNAME_ALREADY_EXISTS(400, "이미 사용 중인 닉네임 입니다."),
+    DUPLICATE_NICKNAME(400, "중복된 닉네임 입니다."),
 
     /* 401 */
     INVALID_CREDENTIAL(401, "아이디 또는 비밀번호가 올바르지 않습니다."),

--- a/src/main/java/com/shcho/myBlog/mypage/controller/MyPageController.java
+++ b/src/main/java/com/shcho/myBlog/mypage/controller/MyPageController.java
@@ -1,14 +1,13 @@
 package com.shcho.myBlog.mypage.controller;
 
 import com.shcho.myBlog.mypage.dto.GetMyPageResponseDto;
+import com.shcho.myBlog.mypage.dto.UpdateNicknameRequestDto;
 import com.shcho.myBlog.mypage.service.MyPageService;
 import com.shcho.myBlog.user.service.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/mypage")
@@ -23,5 +22,21 @@ public class MyPageController {
     ) {
         Long userId = userDetail.getUserId();
         return ResponseEntity.ok(myPageService.getMyPage(userId));
+    }
+
+    @GetMapping("/nickname/{nickname}")
+    public ResponseEntity<?> existsNickname(
+            @PathVariable String nickname
+    ) {
+        return ResponseEntity.ok(myPageService.existsNickname(nickname));
+    }
+
+    @PatchMapping("/nickname")
+    public ResponseEntity<String> updateNickname(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UpdateNicknameRequestDto request
+    ) {
+        Long userId = userDetails.getUserId();
+        return ResponseEntity.ok(myPageService.updateNickname(userId, request.nickname()));
     }
 }

--- a/src/main/java/com/shcho/myBlog/mypage/dto/UpdateNicknameRequestDto.java
+++ b/src/main/java/com/shcho/myBlog/mypage/dto/UpdateNicknameRequestDto.java
@@ -1,0 +1,6 @@
+package com.shcho.myBlog.mypage.dto;
+
+public record UpdateNicknameRequestDto(
+        String nickname
+) {
+}

--- a/src/main/java/com/shcho/myBlog/mypage/service/MyPageService.java
+++ b/src/main/java/com/shcho/myBlog/mypage/service/MyPageService.java
@@ -1,5 +1,7 @@
 package com.shcho.myBlog.mypage.service;
 
+import com.shcho.myBlog.libs.exception.CustomException;
+import com.shcho.myBlog.libs.exception.ErrorCode;
 import com.shcho.myBlog.mypage.dto.GetMyPageResponseDto;
 import com.shcho.myBlog.user.entity.User;
 import com.shcho.myBlog.user.repository.UserRepository;
@@ -15,5 +17,22 @@ public class MyPageService {
     public GetMyPageResponseDto getMyPage(Long userId) {
         User user = userRepository.getReferenceById(userId);
         return GetMyPageResponseDto.from(user);
+    }
+
+    public String updateNickname(Long userId, String nickname) {
+        User user = userRepository.getReferenceById(userId);
+
+        if(existsNickname(nickname)) {
+            throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        user.updateNickname(nickname);
+        userRepository.save(user);
+
+        return user.getNickname();
+    }
+
+    public boolean existsNickname(String nickname) {
+        return userRepository.existsByNickname(nickname);
     }
 }

--- a/src/main/java/com/shcho/myBlog/user/entity/User.java
+++ b/src/main/java/com/shcho/myBlog/user/entity/User.java
@@ -32,4 +32,8 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(50)")
     private Role role;
+
+    public void updateNickname(String newNickname) {
+        this.nickname = newNickname;
+    }
 }


### PR DESCRIPTION
## 🔀 PR 제목
Feat/mypage update nickname

## ✅ 작업 내용
### 1. 닉네임 중복 확인 API 추가
- `GET /api/mypage/nickname/check?nickname={nickname}`
- 닉네임 존재 여부를 boolean 값으로 반환
  - `true`: 이미 존재하는 닉네임
  - `false`: 사용 가능한 닉네임

### 2. 닉네임 수정 API 추가
- `PATCH /api/mypage/nickname`
- 요청 바디: `UpdateNicknameRequestDto`
  - 필드: `nickname`
- 중복되지 않는 경우 해당 사용자 정보에서 닉네임을 변경
- 중복일 경우 `DUPLICATE_NICKNAME` 예외 발생

### 3. 인증 처리
- 두 API 모두 JWT 인증 기반으로 동작
- 인증 실패 시 401 에러 반환

---

## 🔧 개발 상세

- `MyPageController`  
  - `existsNickname()` 메서드 추가  
  - `updateNickname()` 메서드 추가

- `MyPageService`  
  - 닉네임 존재 여부 확인 로직 분리
  - 닉네임 중복 예외 처리 및 업데이트 로직 구현

- `UpdateNicknameRequestDto` 생성 (record 타입 사용)

---

## 📎 관련 이슈
- 닉네임 수정 기능 구현: #10  