### PR TITLE
[Feat] 마이페이지 비밀번호 변경 기능 구현

### DIFF
--- a/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     /* 401 */
     INVALID_CREDENTIAL(401, "아이디 또는 비밀번호가 올바르지 않습니다."),
     JWT_KEY_ERROR(401, "JWT secret 키가 올바르지 않습니다."),
+    INVALID_PASSWORD(401, "비밀번호가 일치하지 않습니다."),
 
     /* 404 NOT_FOUND */
     USER_NOT_FOUND(404, "유저를 찾을 수 없습니다."),

--- a/src/main/java/com/shcho/myBlog/mypage/controller/MyPageController.java
+++ b/src/main/java/com/shcho/myBlog/mypage/controller/MyPageController.java
@@ -2,6 +2,7 @@ package com.shcho.myBlog.mypage.controller;
 
 import com.shcho.myBlog.mypage.dto.GetMyPageResponseDto;
 import com.shcho.myBlog.mypage.dto.UpdateNicknameRequestDto;
+import com.shcho.myBlog.mypage.dto.UpdatePasswordRequestDto;
 import com.shcho.myBlog.mypage.service.MyPageService;
 import com.shcho.myBlog.user.service.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -38,5 +39,14 @@ public class MyPageController {
     ) {
         Long userId = userDetails.getUserId();
         return ResponseEntity.ok(myPageService.updateNickname(userId, request.nickname()));
+    }
+
+    @PatchMapping("/password")
+    public ResponseEntity<String> updatePassword(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UpdatePasswordRequestDto request
+    ) {
+        Long userId = userDetails.getUserId();
+        return ResponseEntity.ok(myPageService.updatePassword(userId, request.currentPassword(), request.newPassword()));
     }
 }

--- a/src/main/java/com/shcho/myBlog/mypage/dto/UpdatePasswordRequestDto.java
+++ b/src/main/java/com/shcho/myBlog/mypage/dto/UpdatePasswordRequestDto.java
@@ -1,6 +1,7 @@
 package com.shcho.myBlog.mypage.dto;
 
 public record UpdatePasswordRequestDto(
-        String password
+        String currentPassword,
+        String newPassword
 ) {
 }

--- a/src/main/java/com/shcho/myBlog/mypage/dto/UpdatePasswordRequestDto.java
+++ b/src/main/java/com/shcho/myBlog/mypage/dto/UpdatePasswordRequestDto.java
@@ -1,0 +1,6 @@
+package com.shcho.myBlog.mypage.dto;
+
+public record UpdatePasswordRequestDto(
+        String password
+) {
+}

--- a/src/main/java/com/shcho/myBlog/mypage/service/MyPageService.java
+++ b/src/main/java/com/shcho/myBlog/mypage/service/MyPageService.java
@@ -6,6 +6,7 @@ import com.shcho.myBlog.mypage.dto.GetMyPageResponseDto;
 import com.shcho.myBlog.user.entity.User;
 import com.shcho.myBlog.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
 public class MyPageService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public GetMyPageResponseDto getMyPage(Long userId) {
         User user = userRepository.getReferenceById(userId);
@@ -34,5 +36,19 @@ public class MyPageService {
 
     public boolean existsNickname(String nickname) {
         return userRepository.existsByNickname(nickname);
+    }
+
+    public String updatePassword(Long userId, String curPassword, String newPassword) {
+        User user = userRepository.getReferenceById(userId);
+
+        if(!passwordEncoder.matches(curPassword, user.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        String encodedPassword = passwordEncoder.encode(newPassword);
+        user.updatePassword(encodedPassword);
+        userRepository.save(user);
+
+        return "비밀번호가 성공적으로 변경되었습니다.";
     }
 }

--- a/src/main/java/com/shcho/myBlog/user/entity/User.java
+++ b/src/main/java/com/shcho/myBlog/user/entity/User.java
@@ -36,4 +36,8 @@ public class User extends BaseEntity {
     public void updateNickname(String newNickname) {
         this.nickname = newNickname;
     }
+
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
 }


### PR DESCRIPTION
## 🔀 PR 제목
마이페이지 비밀번호 변경 기능 구현

## ✅ 작업 내용
- `UpdatePasswordRequestDto` 생성 (`currentPassword`, `newPassword` 필드 포함)
- `MyPageService.updatePassword()` 구현
  - 입력받은 현재 비밀번호를 `PasswordEncoder.matches()`로 비교
  - 일치할 경우, 새 비밀번호를 암호화한 뒤 저장
  - 불일치할 경우, `CustomException` 발생 (`ErrorCode.INVALID_PASSWORD`)
- `MyPageController`에 PATCH `/api/mypage/password` API 추가
- Spring Security의 `PasswordEncoder`를 이용해 비밀번호 암호화 처리
- 응답 처리:
  - 성공 시: 200 OK, `"비밀번호가 성공적으로 변경되었습니다."` 메시지 반환
  - 실패 시: 401 Unauthorized 또는 400 Bad Request 반환


## 🔧 변경사항
- `UpdatePasswordRequestDto.java` 추가
- `MyPageController.java` 수정
- `MyPageService.java` 수정
- `ErrorCode.java` 수정
- `User.java` 수정

## 🧪 테스트 방법
- Postman으로 로그인 후 JWT 포함 요청:
  - PATCH `/api/mypage/password`
  - body: `{ "currentPassword": "old_pw", "newPassword": "new_pw" }`
  - 응답 성공 메시지 및 실제 비밀번호 변경 확인
 
## 📌 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요 -->
- close #11 
