### PR TITLE
[Feat] 마이페이지 회원 탈퇴 기능 구현 및 로그인 제한 처리

### DIFF
--- a/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
@@ -11,11 +11,13 @@ public enum ErrorCode {
     USER_ALREADY_EXISTS(400, "이미 존재하는 사용자 입니다."),
     NICKNAME_ALREADY_EXISTS(400, "이미 사용 중인 닉네임 입니다."),
     DUPLICATE_NICKNAME(400, "중복된 닉네임 입니다."),
+    ALREADY_DELETED_USER(400, "이미 탈퇴한 사용자입니다."),
 
     /* 401 */
     INVALID_CREDENTIAL(401, "아이디 또는 비밀번호가 올바르지 않습니다."),
     JWT_KEY_ERROR(401, "JWT secret 키가 올바르지 않습니다."),
     INVALID_PASSWORD(401, "비밀번호가 일치하지 않습니다."),
+    DELETED_USER_CANNOT_LOGIN(401, "탈퇴한 사용자는 로그인할 수 없습니다."),
 
     /* 404 NOT_FOUND */
     USER_NOT_FOUND(404, "유저를 찾을 수 없습니다."),

--- a/src/main/java/com/shcho/myBlog/mypage/controller/MyPageController.java
+++ b/src/main/java/com/shcho/myBlog/mypage/controller/MyPageController.java
@@ -49,4 +49,12 @@ public class MyPageController {
         Long userId = userDetails.getUserId();
         return ResponseEntity.ok(myPageService.updatePassword(userId, request.currentPassword(), request.newPassword()));
     }
+
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<String> withdraw(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+        return ResponseEntity.ok(myPageService.withdraw(userId));
+    }
 }

--- a/src/main/java/com/shcho/myBlog/mypage/service/MyPageService.java
+++ b/src/main/java/com/shcho/myBlog/mypage/service/MyPageService.java
@@ -51,4 +51,12 @@ public class MyPageService {
 
         return "비밀번호가 성공적으로 변경되었습니다.";
     }
+
+    public String withdraw(Long userId) {
+        User user = userRepository.getReferenceById(userId);
+        user.withdraw();
+        userRepository.save(user);
+
+        return "회원 탈퇴가 완료되었습니다.";
+    }
 }

--- a/src/main/java/com/shcho/myBlog/user/dto/UserSignUpRequestDto.java
+++ b/src/main/java/com/shcho/myBlog/user/dto/UserSignUpRequestDto.java
@@ -1,8 +1,13 @@
 package com.shcho.myBlog.user.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record UserSignUpRequestDto(
+        @NotBlank(message = "아이디는 필수입니다.")
         String username,
+        @NotBlank(message = "비밀번호는 필수입니다.")
         String password,
+        @NotBlank(message = "닉네임은 필수입니다.")
         String nickname
 ) {
 }

--- a/src/main/java/com/shcho/myBlog/user/entity/User.java
+++ b/src/main/java/com/shcho/myBlog/user/entity/User.java
@@ -2,7 +2,6 @@ package com.shcho.myBlog.user.entity;
 
 import com.shcho.myBlog.libs.entity.BaseEntity;
 import com.shcho.myBlog.libs.exception.CustomException;
-import com.shcho.myBlog.libs.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -51,7 +50,7 @@ public class User extends BaseEntity {
     }
 
     public void withdraw() {
-        if(this.deletedAt != null) {
+        if (this.deletedAt != null) {
             throw new CustomException(ALREADY_DELETED_USER);
         }
         this.deletedAt = LocalDateTime.now();

--- a/src/main/java/com/shcho/myBlog/user/entity/User.java
+++ b/src/main/java/com/shcho/myBlog/user/entity/User.java
@@ -38,7 +38,6 @@ public class User extends BaseEntity {
     @Column(columnDefinition = "VARCHAR(50)")
     private Role role;
 
-    @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
     public void updateNickname(String newNickname) {

--- a/src/main/java/com/shcho/myBlog/user/entity/User.java
+++ b/src/main/java/com/shcho/myBlog/user/entity/User.java
@@ -1,12 +1,18 @@
 package com.shcho.myBlog.user.entity;
 
 import com.shcho.myBlog.libs.entity.BaseEntity;
+import com.shcho.myBlog.libs.exception.CustomException;
+import com.shcho.myBlog.libs.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+import static com.shcho.myBlog.libs.exception.ErrorCode.ALREADY_DELETED_USER;
 
 @Entity
 @Builder
@@ -20,18 +26,21 @@ public class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true)
     private String username;
 
     @Column(nullable = false)
     private String password;
 
-    @Column(unique = true, nullable = false)
+    @Column(unique = true)
     private String nickname;
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(50)")
     private Role role;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     public void updateNickname(String newNickname) {
         this.nickname = newNickname;
@@ -39,5 +48,19 @@ public class User extends BaseEntity {
 
     public void updatePassword(String encodedPassword) {
         this.password = encodedPassword;
+    }
+
+    public void withdraw() {
+        if(this.deletedAt != null) {
+            throw new CustomException(ALREADY_DELETED_USER);
+        }
+        this.deletedAt = LocalDateTime.now();
+        this.username = null;
+        this.password = "";
+        this.nickname = null;
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
     }
 }

--- a/src/main/java/com/shcho/myBlog/user/service/CustomUserDetailService.java
+++ b/src/main/java/com/shcho/myBlog/user/service/CustomUserDetailService.java
@@ -1,6 +1,7 @@
 package com.shcho.myBlog.user.service;
 
 import com.shcho.myBlog.libs.exception.CustomException;
+import com.shcho.myBlog.libs.exception.ErrorCode;
 import com.shcho.myBlog.user.entity.User;
 import com.shcho.myBlog.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,10 @@ public class CustomUserDetailService implements UserDetailsService {
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if(user.isDeleted()) {
+            throw new CustomException(ErrorCode.DELETED_USER_CANNOT_LOGIN);
+        }
 
         return new CustomUserDetails(user);
     }


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] 마이페이지 회원 탈퇴 기능 구현 및 로그인 제한 처리

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 요약해서 적어주세요 -->
- 회원 탈퇴 API(`DELETE /api/mypage/withdraw`) 구현
- 탈퇴 시 `User.deletedAt`에 현재 시간 기록, 주요 개인정보 마스킹 (`username`, `nickname`, `password` -> `null`)
- 삭제된 사용자는 로그인 및 마이페이지 진입 불가 (`CustomUserDetailService` 내 isDeleted() 검사 추가)
- 회원가입 요청 DTO에 유효성 검증 어노테이션 추가
- User 엔티티 컬럼 정비 (nullable = false) 적용

## 🔧 변경사항
<!-- 어떤 파일이 추가/수정/삭제되었는지 -->
- `User.java` -> deletedAt 필드 추가 및 `withdraw()`, `isDelete()` 구현
- `MyPageService.java` -> 탈퇴 로직 추가
- `MyPageController.java` -> 탈퇴 API 추가
- `CustomUserDetailService.java` -> 삭제된 사용자 로그인 제한 처리
- `UserSignUpRequestDto.java` -> 필드 유효성 검증 어노테이션 추가

## 📌 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요 -->
- close #16 
