### PR TITLE
[Feat] 파일 업로드 기능 (MinIO 연동) 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	// dotenv
 	implementation 'me.paulschwarz:spring-dotenv:2.3.0'
 
+	// minio
+	implementation 'io.minio:minio:8.5.7'
+
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/src/main/java/com/shcho/myBlog/common/config/MinioConfig.java
+++ b/src/main/java/com/shcho/myBlog/common/config/MinioConfig.java
@@ -1,0 +1,29 @@
+package com.shcho.myBlog.common.config;
+
+import io.minio.MinioClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class MinioConfig {
+
+    @Value("${minio.url}")
+    private String url;
+
+    @Value("${minio.access-key}")
+    private String accessKey;
+
+    @Value("${minio.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public MinioClient minioClient() {
+        return MinioClient.builder()
+                .endpoint(url)
+                .credentials(accessKey, secretKey)
+                .build();
+    }
+}

--- a/src/main/java/com/shcho/myBlog/common/controller/FileUploadController.java
+++ b/src/main/java/com/shcho/myBlog/common/controller/FileUploadController.java
@@ -1,0 +1,28 @@
+package com.shcho.myBlog.common.controller;
+
+import com.shcho.myBlog.common.dto.FileUploadResponseDto;
+import com.shcho.myBlog.common.service.S3Service;
+import com.shcho.myBlog.user.service.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/files")
+@RequiredArgsConstructor
+public class FileUploadController {
+
+    private final S3Service s3Service;
+
+    @PostMapping("/upload")
+    public ResponseEntity<FileUploadResponseDto> uploadFile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestPart MultipartFile file,
+            @RequestParam("type") String type
+    ) {
+        String username = userDetails.getUsername();
+        return ResponseEntity.ok(s3Service.uploadFile(file, type, username));
+    }
+}

--- a/src/main/java/com/shcho/myBlog/common/dto/FileUploadResponseDto.java
+++ b/src/main/java/com/shcho/myBlog/common/dto/FileUploadResponseDto.java
@@ -1,0 +1,14 @@
+package com.shcho.myBlog.common.dto;
+
+import lombok.Builder;
+
+@Builder
+public record FileUploadResponseDto(
+        String url
+) {
+    public static FileUploadResponseDto from(String url) {
+        return FileUploadResponseDto.builder()
+                .url(url)
+                .build();
+    }
+}

--- a/src/main/java/com/shcho/myBlog/common/service/S3Service.java
+++ b/src/main/java/com/shcho/myBlog/common/service/S3Service.java
@@ -1,0 +1,54 @@
+package com.shcho.myBlog.common.service;
+
+import com.shcho.myBlog.common.dto.FileUploadResponseDto;
+import com.shcho.myBlog.libs.exception.CustomException;
+import com.shcho.myBlog.libs.exception.ErrorCode;
+import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3Service {
+
+    private final MinioClient minioClient;
+    private final String bucket = "shblog";
+
+    public FileUploadResponseDto uploadFile(MultipartFile file, String dir, String username) {
+        try {
+            String originalFilename = file.getOriginalFilename();
+            String fileExtension = getFileExtension(originalFilename);
+
+            String uuid = UUID.randomUUID().toString();
+            String fileName = String.format("%s/%s-%s%s", dir, username, uuid, fileExtension);
+
+            minioClient.putObject(
+                    PutObjectArgs.builder()
+                            .bucket(bucket)
+                            .object(fileName)
+                            .stream(file.getInputStream(), file.getSize(), - 1L)
+                            .contentType(file.getContentType())
+                            .build()
+            );
+
+            String url = String.format("https://minio-api.csh980116.synology.me/shblog/%s", fileName);
+            return FileUploadResponseDto.from(url);
+        } catch (Exception e) {
+            log.error("[Minio] 파일 업로드 실패: {}", e.getMessage());
+            throw new CustomException(ErrorCode.FILE_UPLOAD_FAIL);
+        }
+    }
+
+    private String getFileExtension(String originalFilename) {
+        if(originalFilename == null || !originalFilename.contains(".")) {
+            return "";
+        }
+        return originalFilename.substring(originalFilename.lastIndexOf("."));
+    }
+}

--- a/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
@@ -23,7 +23,8 @@ public enum ErrorCode {
     USER_NOT_FOUND(404, "유저를 찾을 수 없습니다."),
 
     /* 500 INTERNAL_SERVER_ERROR */
-    INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다."),
+    FILE_UPLOAD_FAIL(500, "파일 업로드에 실패하였습니다.");
 
     private final Integer httpStatus;
     private final String message;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,12 @@ spring:
 jwt:
   secret: ${JWT_SECRET}
 
+minio:
+  url: ${MINIO_URL}
+  access-key: ${MINIO_ACCESS_KEY}
+  secret-key: ${MINIO_SECRET_KEY}
+  bucket: shblog
+
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] 파일 업로드 기능 (MinIO 연동) 구현

## ✅ 작업 내용
- 개인 NAS 서버에 구축된 MinIO를 사용하여 이미지 업로드 기능 구현
- 업로드된 파일을 `/profile/{username}-{uuid}` 또는 `/post/{username}-{uuid}` 형식으로 저장
- 업로드 성공 시 외부에서 접근 가능한 URL 반환
- 실패 시 커스텀 예외 처리 (`FILE_UPLOAD_FAIL`)

## 🔧 변경사항
- `MinioConfig.java` 추가
- `S3Service.java` 추가
- `FileUploadController.java` 추가
- `FileUploadResponseDto.java` 추가
- `.env`에 MINIO 관련 설정 추가

## 📌 관련 이슈
- close #22

## 📎 참고 자료
- [MinIO 연동 방법 (NAS 환경)](https://sohyun1489.tistory.com/29)
- [Synology NAS에 MinIO 설치 및 설정](https://joojae.com/synology-nas-object-storage-minio/)

