### PR TITLE
[Feat] 마이페이지 프로필 이미지 등록 및 수정 기능 구현

### DIFF
--- a/src/main/java/com/shcho/myBlog/mypage/controller/MyPageController.java
+++ b/src/main/java/com/shcho/myBlog/mypage/controller/MyPageController.java
@@ -3,6 +3,7 @@ package com.shcho.myBlog.mypage.controller;
 import com.shcho.myBlog.mypage.dto.GetMyPageResponseDto;
 import com.shcho.myBlog.mypage.dto.UpdateNicknameRequestDto;
 import com.shcho.myBlog.mypage.dto.UpdatePasswordRequestDto;
+import com.shcho.myBlog.mypage.dto.UpdateProfileImageRequestDto;
 import com.shcho.myBlog.mypage.service.MyPageService;
 import com.shcho.myBlog.user.service.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -48,6 +49,15 @@ public class MyPageController {
     ) {
         Long userId = userDetails.getUserId();
         return ResponseEntity.ok(myPageService.updatePassword(userId, request.currentPassword(), request.newPassword()));
+    }
+
+    @PatchMapping("/profile-image")
+    public ResponseEntity<String> updateProfileImage(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UpdateProfileImageRequestDto request
+    ) {
+        Long userId = userDetails.getUserId();
+        return ResponseEntity.ok(myPageService.updateProfileImage(userId, request.fileUrl()));
     }
 
     @DeleteMapping("/withdraw")

--- a/src/main/java/com/shcho/myBlog/mypage/dto/GetMyPageResponseDto.java
+++ b/src/main/java/com/shcho/myBlog/mypage/dto/GetMyPageResponseDto.java
@@ -8,12 +8,14 @@ import lombok.Builder;
 public record GetMyPageResponseDto(
         String username,
         String nickname,
+        String profileImageUrl,
         Role role
 ) {
     public static GetMyPageResponseDto from(User user) {
         return GetMyPageResponseDto.builder()
                 .username(user.getUsername())
                 .nickname(user.getNickname())
+                .profileImageUrl(user.getProfileImageUrl())
                 .role(user.getRole())
                 .build();
     }

--- a/src/main/java/com/shcho/myBlog/mypage/dto/UpdateProfileImageRequestDto.java
+++ b/src/main/java/com/shcho/myBlog/mypage/dto/UpdateProfileImageRequestDto.java
@@ -1,0 +1,6 @@
+package com.shcho.myBlog.mypage.dto;
+
+public record UpdateProfileImageRequestDto(
+        String fileUrl
+) {
+}

--- a/src/main/java/com/shcho/myBlog/mypage/service/MyPageService.java
+++ b/src/main/java/com/shcho/myBlog/mypage/service/MyPageService.java
@@ -52,6 +52,14 @@ public class MyPageService {
         return "비밀번호가 성공적으로 변경되었습니다.";
     }
 
+    public String updateProfileImage(Long userId, String fileUrl) {
+        User user = userRepository.getReferenceById(userId);
+        user.updateProfileImage(fileUrl);
+        userRepository.save(user);
+
+        return "프로필 사진이 성공적으로 변경되었습니다.";
+    }
+
     public String withdraw(Long userId) {
         User user = userRepository.getReferenceById(userId);
         user.withdraw();

--- a/src/main/java/com/shcho/myBlog/user/entity/User.java
+++ b/src/main/java/com/shcho/myBlog/user/entity/User.java
@@ -34,6 +34,9 @@ public class User extends BaseEntity {
     @Column(unique = true)
     private String nickname;
 
+    @Column
+    private String profileImageUrl;
+
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(50)")
     private Role role;
@@ -46,6 +49,10 @@ public class User extends BaseEntity {
 
     public void updatePassword(String encodedPassword) {
         this.password = encodedPassword;
+    }
+
+    public void updateProfileImage(String fileUrl) {
+        this.profileImageUrl = fileUrl;
     }
 
     public void withdraw() {


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] 마이페이지 프로필 이미지 등록 및 수정 기능 구현

## ✅ 작업 내용
- `User` 엔티티에 `profileImageUrl` 필드 추가
- 프로필 이미지 응답 필드 `GetMyPageResponseDto`에 포함
- 마이페이지 API에 프로필 이미지 변경 엔드포인트 추가 (`PATCH /api/mypage/profile-image`)
- `S3Service.uploadImage()`를 통해 이미지 확장자 검증 및 업로드
- 업로드된 이미지 URL을 사용자 정보에 반영

## 🔧 변경사항
- `User.java`: 프로필 이미지 필드 추가 및 setter 메서드 작성
- `MyPageController`, `MyPageService`: 이미지 업데이트 로직 추가
- `GetMyPageResponseDto`, `UpdateProfileImageRequestDto`: 관련 DTO 정의
- `S3Service`: 이미지 검증 및 업로드 분리 (`uploadImage`)

## 📌 관련 이슈
- close #26 

## 📎 참고 자료
- 이미지 업로드 API: `/api/files/upload`
- 저장 형식: `https://minio-api.csh980116.synology.me/shblog/profile/{username}-{uuid}.{확장자}`
- 인증 방식: `@AuthenticationPrincipal`로 사용자 식별
