### PR TITLE
[Test] 마이페이지 프로필 이미지 업데이트 테스트 코드 추가

### DIFF
--- a/src/test/java/com/shcho/myBlog/common/service/S3ServiceTest.java
+++ b/src/test/java/com/shcho/myBlog/common/service/S3ServiceTest.java
@@ -11,6 +11,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static com.shcho.myBlog.libs.exception.ErrorCode.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -18,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @DisplayName("파일 업로드 서비스 테스트")
+@ActiveProfiles("test")
 class S3ServiceTest {
 
     @Mock
@@ -29,6 +32,7 @@ class S3ServiceTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
+        ReflectionTestUtils.setField(s3Service, "bucket", "shblog");
     }
 
     @Test

--- a/src/test/java/com/shcho/myBlog/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/shcho/myBlog/mypage/service/MyPageServiceTest.java
@@ -16,6 +16,7 @@ import static com.shcho.myBlog.libs.exception.ErrorCode.INVALID_PASSWORD;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@DisplayName("마이페이지 서비스 테스트")
 class MyPageServiceTest {
 
     @Mock
@@ -181,6 +182,31 @@ class MyPageServiceTest {
         assertNull(user.getUsername());
         assertEquals("", user.getPassword());
         assertNull(user.getNickname());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 업데이트 성공")
+    void updateProfileImageSuccess() {
+        // given
+        Long userId = 1L;
+        String newImageUrl = "http://new-image-url";
+
+        User user = User.builder()
+                .username("username")
+                .password("password")
+                .nickname("nickname")
+                .role(Role.USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        // when
+        String result = myPageService.updateProfileImage(userId, newImageUrl);
+
+        // then
+        assertEquals("프로필 사진이 성공적으로 변경되었습니다.", result);
+        assertEquals(newImageUrl, user.getProfileImageUrl());
         verify(userRepository).save(user);
     }
 }


### PR DESCRIPTION
## 🔀 PR 제목
[test] 마이페이지 프로필 이미지 업데이트 테스트 코드 추가

## ✅ 작업 내용
- 마이페이지 서비스의 프로필 이미지 수정 기능 단위 테스트 작성
- 사용자 엔티티의 `profileImageUrl` 필드가 정상적으로 변경되는지 검증
- 저장 로직(`userRepository.save()`) 호출 여부 확인

## 🔧 변경사항
- `MyPageServiceTest.java` 테스트 클래스에 `updateProfileImageSuccess()` 테스트 메서드 추가

## 📌 관련 이슈
- close #30 

## 📎 참고 자료
- 기존 마이페이지 기능 코드 참고
