### PR TITLE
[Feat] Post, Category 도메인 및 기본 구조 설계

### DIFF
--- a/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
@@ -15,12 +15,16 @@ public enum ErrorCode {
     INVALID_IMAGE_FORMAT(400, "지원하지 않는 이미지 형식입니다."),
     INVALID_FILE_FORMAT(400, "지원하지 않는 파일 형식입니다."),
     INVALID_FILE_TYPE(400, "지원하지 않는 파일 타입입니다."),
+    DUPLICATE_CATEGORY(400, "중복된 카테고리명 입니다."),
 
     /* 401 */
     INVALID_CREDENTIAL(401, "아이디 또는 비밀번호가 올바르지 않습니다."),
     JWT_KEY_ERROR(401, "JWT secret 키가 올바르지 않습니다."),
     INVALID_PASSWORD(401, "비밀번호가 일치하지 않습니다."),
     DELETED_USER_CANNOT_LOGIN(401, "탈퇴한 사용자는 로그인할 수 없습니다."),
+
+    /* 403 */
+    UNAUTHORIZED_CATEGORY_ACCESS(403, "해당 카테고리에 대한 접근 권한이 없습니다."),
 
     /* 404 NOT_FOUND */
     USER_NOT_FOUND(404, "유저를 찾을 수 없습니다."),

--- a/src/main/java/com/shcho/myBlog/post/controller/CategoryController.java
+++ b/src/main/java/com/shcho/myBlog/post/controller/CategoryController.java
@@ -1,0 +1,46 @@
+package com.shcho.myBlog.post.controller;
+
+import com.shcho.myBlog.post.dto.CategoryCreateRequestDto;
+import com.shcho.myBlog.post.dto.CategoryResponseDto;
+import com.shcho.myBlog.post.service.CategoryService;
+import com.shcho.myBlog.user.service.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @PostMapping
+    public ResponseEntity<CategoryResponseDto> createCategory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody CategoryCreateRequestDto request
+    ) {
+        Long userId = userDetails.getUserId();
+        return ResponseEntity.ok(categoryService.createCategory(userId, request.name()));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CategoryResponseDto>> getCategories(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+        return ResponseEntity.ok(categoryService.getCategories(userId));
+    }
+
+    @DeleteMapping("/{categoryId}")
+    public ResponseEntity<String> deleteCategory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long categoryId
+    ) {
+        Long userId = userDetails.getUserId();
+        return ResponseEntity.ok(categoryService.deleteCategory(userId, categoryId));
+    }
+}

--- a/src/main/java/com/shcho/myBlog/post/dto/CategoryCreateRequestDto.java
+++ b/src/main/java/com/shcho/myBlog/post/dto/CategoryCreateRequestDto.java
@@ -1,0 +1,6 @@
+package com.shcho.myBlog.post.dto;
+
+public record CategoryCreateRequestDto(
+        String name
+) {
+}

--- a/src/main/java/com/shcho/myBlog/post/dto/CategoryResponseDto.java
+++ b/src/main/java/com/shcho/myBlog/post/dto/CategoryResponseDto.java
@@ -1,0 +1,12 @@
+package com.shcho.myBlog.post.dto;
+
+import com.shcho.myBlog.post.entity.Category;
+
+public record CategoryResponseDto(
+        Long categoryId,
+        String name
+) {
+    public static CategoryResponseDto from(Category category) {
+        return new CategoryResponseDto(category.getId(), category.getName());
+    }
+}

--- a/src/main/java/com/shcho/myBlog/post/dto/PostCreateRequestDto.java
+++ b/src/main/java/com/shcho/myBlog/post/dto/PostCreateRequestDto.java
@@ -1,0 +1,10 @@
+package com.shcho.myBlog.post.dto;
+
+import com.shcho.myBlog.post.entity.Category;
+
+public record PostCreateRequestDto (
+        String title,
+        String content,
+        Category category
+){
+}

--- a/src/main/java/com/shcho/myBlog/post/dto/PostResponseDto.java
+++ b/src/main/java/com/shcho/myBlog/post/dto/PostResponseDto.java
@@ -1,0 +1,15 @@
+package com.shcho.myBlog.post.dto;
+
+import com.shcho.myBlog.post.entity.Category;
+
+import java.time.LocalDateTime;
+
+public record PostResponseDto(
+        Long postId,
+        String title,
+        String content,
+        Category category,
+        Long userId,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/shcho/myBlog/post/entity/Category.java
+++ b/src/main/java/com/shcho/myBlog/post/entity/Category.java
@@ -1,0 +1,41 @@
+package com.shcho.myBlog.post.entity;
+
+import com.shcho.myBlog.libs.entity.BaseEntity;
+import com.shcho.myBlog.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(
+        name = "category",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "name"})
+        }
+)
+public class Category extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public static Category of(String name, User user) {
+        return Category.builder()
+                .name(name)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/shcho/myBlog/post/entity/Post.java
+++ b/src/main/java/com/shcho/myBlog/post/entity/Post.java
@@ -1,0 +1,41 @@
+package com.shcho.myBlog.post.entity;
+
+import com.shcho.myBlog.libs.entity.BaseEntity;
+import com.shcho.myBlog.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    private LocalDateTime deletedAt;
+
+    public boolean isDeleted(){
+        return deletedAt != null;
+    }
+}

--- a/src/main/java/com/shcho/myBlog/post/repository/CategoryRepository.java
+++ b/src/main/java/com/shcho/myBlog/post/repository/CategoryRepository.java
@@ -1,0 +1,12 @@
+package com.shcho.myBlog.post.repository;
+
+import com.shcho.myBlog.post.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    List<Category> findAllByUserId(Long userId);
+
+    boolean existsByUserIdAndName(Long userId, String name);
+}

--- a/src/main/java/com/shcho/myBlog/post/repository/PostRepository.java
+++ b/src/main/java/com/shcho/myBlog/post/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.shcho.myBlog.post.repository;
+
+import com.shcho.myBlog.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/shcho/myBlog/post/service/CategoryService.java
+++ b/src/main/java/com/shcho/myBlog/post/service/CategoryService.java
@@ -1,0 +1,55 @@
+package com.shcho.myBlog.post.service;
+
+import com.shcho.myBlog.libs.exception.CustomException;
+import com.shcho.myBlog.libs.exception.ErrorCode;
+import com.shcho.myBlog.post.dto.CategoryResponseDto;
+import com.shcho.myBlog.post.entity.Category;
+import com.shcho.myBlog.post.repository.CategoryRepository;
+import com.shcho.myBlog.user.entity.User;
+import com.shcho.myBlog.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+    private final UserRepository userRepository;
+
+    public CategoryResponseDto createCategory(Long userId, String name) {
+        User user = userRepository.getReferenceById(userId);
+
+        if(categoryRepository.existsByUserIdAndName(user.getId(),name)) {
+            throw new CustomException(ErrorCode.DUPLICATE_CATEGORY);
+        }
+
+        Category category = Category.of(name, user);
+        categoryRepository.save(category);
+
+        return CategoryResponseDto.from(category);
+    }
+
+    public List<CategoryResponseDto> getCategories(Long userId) {
+        return categoryRepository.findAllByUserId(userId)
+                .stream()
+                .map(CategoryResponseDto::from)
+                .toList();
+    }
+
+    @Transactional
+    public String deleteCategory(Long userId, Long categoryId) {
+        User user = userRepository.getReferenceById(userId);
+        Category category = categoryRepository.getReferenceById(categoryId);
+
+        if(!user.equals(category.getUser())) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_CATEGORY_ACCESS);
+        }
+
+        categoryRepository.deleteById(categoryId);
+        return "카테고리가 삭제되었습니다.";
+    }
+}


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] Post, Category 도메인 및 기본 구조 설계

## ✅ 작업 내용
- Post 엔티티 및 PostCreateRequestDto, PostResponseDto 생성
- Category 엔티티 및 CategoryCreateRequestDto, CategoryResponseDto 생성
- Category 생성, 조회, 삭제 API 구성 (POST, GET, DELETE)
- User와의 연관관계 설정 (User 1:N Category, User 1:N Post)

## 🔧 변경사항
## 🔧 변경사항
- `Post.java`, `Category.java` 엔티티 추가
- `PostCreateRequestDto`, `PostResponseDto`, `CategoryCreateRequestDto`, `CategoryResponseDto` 생성
- `CategoryService.java`, `CategoryController.java` 작성
- 기존 Post 엔티티에서 String category → Category 연관관계로 수정

## 📌 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요 -->
- closes: #33 
- closes: #34 
