### PR TITLE
[Feat] 게시글 조회 기능에 QueryDSL 기반 필터 및 검색 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,5 @@ out/
 
 # 환경변수 파일
 .env
+/src/main/generated/
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,12 @@ dependencies {
 	// minio
 	implementation 'io.minio:minio:8.5.7'
 
+	// queryDsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
@@ -52,6 +58,16 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+def querydslDir = "src/main/generated"
+
+sourceSets {
+	main.java.srcDirs += querydslDir
+}
+
+tasks.withType(JavaCompile).configureEach {
+	options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
 }
 
 bootRun {

--- a/src/main/java/com/shcho/myBlog/common/config/QuerydslConfig.java
+++ b/src/main/java/com/shcho/myBlog/common/config/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package com.shcho.myBlog.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/shcho/myBlog/common/dto/PageResponseDto.java
+++ b/src/main/java/com/shcho/myBlog/common/dto/PageResponseDto.java
@@ -1,0 +1,14 @@
+package com.shcho.myBlog.common.dto;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponseDto<T>(
+        List<T> data,
+        PaginationDto paginationDto
+) {
+    public static <T> PageResponseDto<T> from(Page<T> page) {
+        return new PageResponseDto<>(page.getContent(), PaginationDto.from(page));
+    }
+}

--- a/src/main/java/com/shcho/myBlog/common/dto/PaginationDto.java
+++ b/src/main/java/com/shcho/myBlog/common/dto/PaginationDto.java
@@ -1,0 +1,23 @@
+package com.shcho.myBlog.common.dto;
+
+import org.springframework.data.domain.Page;
+
+public record PaginationDto(
+        int currentPage,
+        int limit,
+        long totalItems,
+        int totalPages,
+        boolean hasNext,
+        boolean hasPrevious
+) {
+    public static PaginationDto from(Page<?> page) {
+        return new PaginationDto(
+                page.getNumber() + 1,
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.hasNext(),
+                page.hasPrevious()
+        );
+    }
+}

--- a/src/main/java/com/shcho/myBlog/post/repository/PostQueryDslRepository.java
+++ b/src/main/java/com/shcho/myBlog/post/repository/PostQueryDslRepository.java
@@ -1,0 +1,69 @@
+package com.shcho.myBlog.post.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.shcho.myBlog.post.dto.PostResponseDto;
+import com.shcho.myBlog.post.entity.QCategory;
+import com.shcho.myBlog.post.entity.QPost;
+import com.shcho.myBlog.user.entity.QUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.shcho.myBlog.post.entity.QPost.post;
+
+@Repository
+@RequiredArgsConstructor
+public class PostQueryDslRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Page<PostResponseDto> findAllByFilter(Long userId, String keyword, Long categoryId, String sort, Pageable pageable) {
+        QPost p = post;
+        QCategory c = QCategory.category;
+        QUser user = QUser.user;
+
+        var query = queryFactory
+                .selectFrom(p)
+                .join(p.category, c).fetchJoin()
+                .join(p.user, user).fetchJoin()
+                .where(
+                        p.user.id.eq(userId),
+                        p.deletedAt.isNull(),
+                        keyword != null ? (p.title.containsIgnoreCase(keyword)
+                                .or(p.content.containsIgnoreCase(keyword))) : null,
+                        categoryId == null ? null : p.category.id.eq(categoryId)
+                );
+
+        if ("oldest".equals(sort)) {
+            query.orderBy(p.createdAt.asc());
+        } else {
+            query.orderBy(p.createdAt.desc());
+        }
+
+        List<PostResponseDto> content = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch()
+                .stream()
+                .map(PostResponseDto::of)
+                .toList();
+
+        Long total = queryFactory
+                .select(p.count())
+                .from(p)
+                .where(
+                        p.user.id.eq(userId),
+                        p.deletedAt.isNull(),
+                        keyword != null ? (p.title.containsIgnoreCase(keyword)
+                                .or(p.content.containsIgnoreCase(keyword))) : null,
+                        categoryId != null ? p.category.id.eq(categoryId) : null
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0);
+    }
+}

--- a/src/main/java/com/shcho/myBlog/post/service/PostService.java
+++ b/src/main/java/com/shcho/myBlog/post/service/PostService.java
@@ -1,20 +1,22 @@
 package com.shcho.myBlog.post.service;
 
 import com.shcho.myBlog.libs.exception.CustomException;
-import com.shcho.myBlog.libs.exception.ErrorCode;
 import com.shcho.myBlog.post.dto.PostCreateRequestDto;
+import com.shcho.myBlog.post.dto.PostResponseDto;
 import com.shcho.myBlog.post.dto.PostUpdateRequestDto;
 import com.shcho.myBlog.post.entity.Category;
 import com.shcho.myBlog.post.entity.Post;
 import com.shcho.myBlog.post.repository.CategoryRepository;
+import com.shcho.myBlog.post.repository.PostQueryDslRepository;
 import com.shcho.myBlog.post.repository.PostRepository;
 import com.shcho.myBlog.user.entity.User;
 import com.shcho.myBlog.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
+import static com.shcho.myBlog.libs.exception.ErrorCode.ALREADY_DELETED_POST;
 import static com.shcho.myBlog.libs.exception.ErrorCode.UNAUTHORIZED_POST_ACCESS;
 
 @Service
@@ -24,6 +26,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final CategoryRepository categoryRepository;
+    private final PostQueryDslRepository postQueryDslRepository;
 
     public Post createPost(Long userId, PostCreateRequestDto request) {
         User user = userRepository.getReferenceById(userId);
@@ -53,16 +56,16 @@ public class PostService {
     public Post getPost(Long postId) {
         Post post = postRepository.getReferenceById(postId);
 
-        if(post.isDeleted()) {
-            throw new CustomException(ErrorCode.ALREADY_DELETED_POST);
+        if (post.isDeleted()) {
+            throw new CustomException(ALREADY_DELETED_POST);
         }
 
         return post;
     }
 
-    // TODO : 페이지네이션 구현
-    public List<Post> getPosts(Long userId) {
-        return postRepository.findAllByUserIdAndDeletedAtIsNull(userId);
+    public Page<PostResponseDto> getPosts(Long userId, String keyword, Long categoryId, String sort, Pageable pageable
+    ) {
+        return postQueryDslRepository.findAllByFilter(userId, keyword, categoryId, sort, pageable);
     }
 
     public String deletePost(Long userId, Long postId) {


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] 게시글 조회 기능에 QueryDSL 기반 필터 및 검색 기능 추가

## ✅ 작업 내용
- QueryDSL 사용을 위한 의존성 추가 및 `.gitignore`, 경로 설정
- `PageResponseDto`, `paginationDto` 등 페이지네이션 응답 포맷 클래스 추가
- `QuerydslConfig` 설정 파일 및 `PostQueryDslRepository` 생성
- 카테고리, 정렬, 키워드 기반 게시글 조회 QueryDSL 로직 구현
- `PostService.getPosts()` 리팩터링 및 `/api/post`, `/api/post/search` API 분리 구현

## 🔧 변경사항
- `build.gradle`: QueryDSL 관련 의존성 및 kapt 설정 추가
- `.gitignore`: `QClass` 생성 파일 제외 처리 (`src/main/generated/`)
- `common.dto`: 페이지네이션 응답용 DTO 클래스 추가
- `post.repository`: `PostQueryDslRepository` 생성 및 필터링 로직 구현
- `post.service`, `post.controller`: 조회 API 리팩터링 및 검색 조건 반영

## 📌 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요 -->
- closes #38 
