### PR TITLE
[Test] 카테고리 서비스 유닛 테스트 작성

### DIFF
--- a/src/main/java/com/shcho/myBlog/post/dto/CategoryCreateRequestDto.java
+++ b/src/main/java/com/shcho/myBlog/post/dto/CategoryCreateRequestDto.java
@@ -1,5 +1,8 @@
 package com.shcho.myBlog.post.dto;
 
+import lombok.Builder;
+
+@Builder
 public record CategoryCreateRequestDto(
         String name
 ) {

--- a/src/main/java/com/shcho/myBlog/post/service/CategoryService.java
+++ b/src/main/java/com/shcho/myBlog/post/service/CategoryService.java
@@ -1,7 +1,6 @@
 package com.shcho.myBlog.post.service;
 
 import com.shcho.myBlog.libs.exception.CustomException;
-import com.shcho.myBlog.libs.exception.ErrorCode;
 import com.shcho.myBlog.post.dto.CategoryResponseDto;
 import com.shcho.myBlog.post.entity.Category;
 import com.shcho.myBlog.post.repository.CategoryRepository;
@@ -13,6 +12,9 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+import static com.shcho.myBlog.libs.exception.ErrorCode.DUPLICATE_CATEGORY;
+import static com.shcho.myBlog.libs.exception.ErrorCode.UNAUTHORIZED_CATEGORY_ACCESS;
+
 @Service
 @RequiredArgsConstructor
 public class CategoryService {
@@ -23,8 +25,8 @@ public class CategoryService {
     public CategoryResponseDto createCategory(Long userId, String name) {
         User user = userRepository.getReferenceById(userId);
 
-        if(categoryRepository.existsByUserIdAndName(user.getId(),name)) {
-            throw new CustomException(ErrorCode.DUPLICATE_CATEGORY);
+        if (categoryRepository.existsByUserIdAndName(user.getId(), name)) {
+            throw new CustomException(DUPLICATE_CATEGORY);
         }
 
         Category category = Category.of(name, user);
@@ -45,8 +47,8 @@ public class CategoryService {
         User user = userRepository.getReferenceById(userId);
         Category category = categoryRepository.getReferenceById(categoryId);
 
-        if(!user.equals(category.getUser())) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED_CATEGORY_ACCESS);
+        if (!user.equals(category.getUser())) {
+            throw new CustomException(UNAUTHORIZED_CATEGORY_ACCESS);
         }
 
         categoryRepository.deleteById(categoryId);

--- a/src/test/java/com/shcho/myBlog/post/service/CategoryServiceTest.java
+++ b/src/test/java/com/shcho/myBlog/post/service/CategoryServiceTest.java
@@ -1,0 +1,157 @@
+package com.shcho.myBlog.post.service;
+
+import com.shcho.myBlog.libs.exception.CustomException;
+import com.shcho.myBlog.post.dto.CategoryCreateRequestDto;
+import com.shcho.myBlog.post.dto.CategoryResponseDto;
+import com.shcho.myBlog.post.entity.Category;
+import com.shcho.myBlog.post.repository.CategoryRepository;
+import com.shcho.myBlog.user.entity.Role;
+import com.shcho.myBlog.user.entity.User;
+import com.shcho.myBlog.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+import static com.shcho.myBlog.libs.exception.ErrorCode.DUPLICATE_CATEGORY;
+import static com.shcho.myBlog.libs.exception.ErrorCode.UNAUTHORIZED_CATEGORY_ACCESS;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@DisplayName("카테고리 서비스 테스트")
+class CategoryServiceTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private CategoryService categoryService;
+
+    public CategoryServiceTest() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .id(1L)
+                .username("username")
+                .password("password")
+                .nickname("nickname")
+                .role(Role.USER)
+                .build();
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 성공")
+    void createCategorySuccess() {
+        // given
+        CategoryCreateRequestDto request = CategoryCreateRequestDto.builder()
+                .name("newCategory")
+                .build();
+
+        when(userRepository.getReferenceById(user.getId())).thenReturn(user);
+        when(categoryRepository.existsByUserIdAndName(user.getId(), request.name())).thenReturn(false);
+
+        // when
+        CategoryResponseDto category = categoryService.createCategory(user.getId(), request.name());
+
+        // then
+        assertNotNull(category);
+        assertEquals(request.name(), category.name());
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 실패 - 존재하지 않는 카테고리")
+    void createCategoryFailDuplicateCategory() {
+        // given
+        CategoryCreateRequestDto request = CategoryCreateRequestDto.builder()
+                .name("newCategory")
+                .build();
+
+        when(userRepository.getReferenceById(user.getId())).thenReturn(user);
+        when(categoryRepository.existsByUserIdAndName(user.getId(), request.name())).thenReturn(true);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> categoryService.createCategory(user.getId(), request.name()));
+
+        assertEquals(DUPLICATE_CATEGORY, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("카테고리 조회 성공")
+    void getCategoriesSuccess() {
+        // given
+        List<Category> mockCategories = List.of(
+                Category.of("분류1", user),
+                Category.of("분류2", user)
+        );
+
+        when(categoryRepository.findAllByUserId(user.getId())).thenReturn(mockCategories);
+
+        // when
+        List<CategoryResponseDto> result = categoryService.getCategories(user.getId());
+
+        // then
+        assertNotNull(result);
+        assertEquals(mockCategories.size(), result.size());
+        assertEquals("분류1", result.get(0).name());
+        assertEquals("분류2", result.get(1).name());
+
+    }
+
+    @Test
+    @DisplayName("카테고리 삭제 성공")
+    void deleteCategorySuccess() {
+        // given
+        Category category = Category.builder()
+                .id(1L)
+                .name("category")
+                .user(user)
+                .build();
+
+        when(userRepository.getReferenceById(user.getId())).thenReturn(user);
+        when(categoryRepository.getReferenceById(category.getId())).thenReturn(category);
+
+        // when
+        String result = categoryService.deleteCategory(user.getId(), category.getId());
+
+        // then
+        assertNotNull(result);
+        assertEquals("카테고리가 삭제되었습니다.", result);
+    }
+
+    @Test
+    @DisplayName("카테고리 삭제 실패 - 유저 권한 없음")
+    void deleteCategoryFailUnauthorizedCategoryAccess() {
+        // given
+        User anotherUser = User.builder()
+                .id(999L)
+                .build();
+
+        Category category = Category.builder()
+                .id(1L)
+                .name("category")
+                .build();
+
+        when(userRepository.getReferenceById(anotherUser.getId())).thenReturn(anotherUser);
+        when(categoryRepository.getReferenceById(category.getId())).thenReturn(category);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> categoryService.deleteCategory(anotherUser.getId(), category.getId()));
+
+        assertEquals(UNAUTHORIZED_CATEGORY_ACCESS, exception.getErrorCode());
+
+    }
+}


### PR DESCRIPTION
## 🔀 PR 제목
[Test] 카테고리 서비스 유닛 테스트 작성

## ✅ 작업 내용
- `CategoryServiceTest` 작성
- 카테고리 생성, 조회, 삭제 로직에 대한 유닛 테스트 구현
  - 중복 예외 및 권한 검증 포함

## 🧪 테스트 항목
- 카테고리 생성 성공
- 카테고리 생성 실패 (중복)
- 카테고리 목록 조회 성공
- 카테고리 삭제 성공
- 카테고리 삭제 실패 (유저 권한 없음)

## 📎 관련 이슈
- closes: #41 


