### PR TITLE
[Feat] Swagger/OpenAPI + JWT 인증 스펙 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/src/main/java/com/shcho/myBlog/common/config/SecurityConfig.java
+++ b/src/main/java/com/shcho/myBlog/common/config/SecurityConfig.java
@@ -26,7 +26,11 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers(
+                                "/api/auth/**",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
                         .requestMatchers("/api/mypage").authenticated()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/shcho/myBlog/common/config/SwaggerConfig.java
+++ b/src/main/java/com/shcho/myBlog/common/config/SwaggerConfig.java
@@ -1,0 +1,43 @@
+package com.shcho.myBlog.common.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "MyBlog API",
+                version = "v1",
+                description = "개인 블로그 프로젝트 백엔드 API 명세"
+        ),
+        security = @SecurityRequirement(name = "bearerAuth")
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth",
+                        new io.swagger.v3.oas.models.security.SecurityScheme()
+                                .type(io.swagger.v3.oas.models.security.SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(io.swagger.v3.oas.models.security.SecurityScheme.In.HEADER)
+                                .name("Authorization")
+                ));
+    }
+}


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] Swagger/OpenAPI + JWT 인증 스펙 추가

## ✅ 작업 내용
- `build.gradle` 에 `springdoc-openapi-starter-webmvc-ui` 의존성 추가  
- `SwaggerConfig.java` 생성 및  
  - `@OpenAPIDefinition`  
  - `@SecurityScheme(name="bearerAuth", type=HTTP, scheme="bearer", bearerFormat="JWT")`  
  - `OpenAPI` 빈에 시큐리티 스킴 등록  
- 컨트롤러 메서드에 `@Operation`, `@Parameter` 어노테이션 적용  
- `SecurityConfig.java` 에 Swagger/OpenAPI 관련 경로 `permitAll()` 추가  
- Swagger UI (`/swagger-ui/index.html`) 접속 확인 및 “Authorize” 버튼 동작 검증  

## 🔧 변경 사항
- **build.gradle**  
  - springdoc-openapi 의존성 버전 업그레이드  
- **SwaggerConfig.java**  
  - OpenAPI 정의 및 JWT 보안 스킴 등록  
- **SecurityConfig.java**  
  - Swagger 관련 경로 `permitAll()` 설정  
- **컨트롤러**  
  - `@Operation`, `@Parameter` 주석 추가  

## 📌 관련 이슈
- closes #47 
