### PR TITLE
[Feat] 댓글 수정·삭제 기능 구현

### DIFF
--- a/src/main/java/com/shcho/myBlog/comment/controller/CommentController.java
+++ b/src/main/java/com/shcho/myBlog/comment/controller/CommentController.java
@@ -1,8 +1,6 @@
 package com.shcho.myBlog.comment.controller;
 
-import com.shcho.myBlog.comment.dto.CommentCreateRequestDto;
-import com.shcho.myBlog.comment.dto.CommentResponseDto;
-import com.shcho.myBlog.comment.dto.CommentWithRepliesDto;
+import com.shcho.myBlog.comment.dto.*;
 import com.shcho.myBlog.comment.entity.Comment;
 import com.shcho.myBlog.comment.service.CommentService;
 import com.shcho.myBlog.common.dto.PageResponseDto;
@@ -40,5 +38,25 @@ public class CommentController {
         Page<CommentWithRepliesDto> commentsWithReplies = commentService.getCommentsWithReplies(postId, pageable);
 
         return ResponseEntity.ok(PageResponseDto.from(commentsWithReplies));
+    }
+
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<CommentResponseDto> updateComment(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long commentId,
+            @Valid @RequestBody CommentUpdateRequestDto request
+    ) {
+        Comment updatedComment = commentService.updateComment(userDetails, commentId, request);
+        return ResponseEntity.ok(CommentResponseDto.from(updatedComment));
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<CommentResponseDto> deleteComment(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long commentId,
+            @RequestBody CommentDeleteRequestDto request
+    ) {
+        Comment deletedComment = commentService.deleteComment(userDetails, commentId, request);
+        return ResponseEntity.ok(CommentResponseDto.from(deletedComment));
     }
 }

--- a/src/main/java/com/shcho/myBlog/comment/dto/CommentDeleteRequestDto.java
+++ b/src/main/java/com/shcho/myBlog/comment/dto/CommentDeleteRequestDto.java
@@ -1,0 +1,6 @@
+package com.shcho.myBlog.comment.dto;
+
+public record CommentDeleteRequestDto(
+        String anonymousPassword
+) {
+}

--- a/src/main/java/com/shcho/myBlog/comment/dto/CommentUpdateRequestDto.java
+++ b/src/main/java/com/shcho/myBlog/comment/dto/CommentUpdateRequestDto.java
@@ -1,0 +1,12 @@
+package com.shcho.myBlog.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CommentUpdateRequestDto(
+        @NotBlank
+        @Size(max = 500)
+        String content,
+        String anonymousPassword
+) {
+}

--- a/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
@@ -26,10 +26,12 @@ public enum ErrorCode {
     /* 403 Forbidden */
     UNAUTHORIZED_CATEGORY_ACCESS(403, "해당 카테고리에 대한 접근 권한이 없습니다."),
     UNAUTHORIZED_POST_ACCESS(403, "해당 게시글에 대한 접근 권한이 없습니다."),
+    UNAUTHORIZED_COMMENT_ACCESS(403, "해당 댓글에 대한 접근 권한이 없습니다."),
 
     /* 404 NOT_FOUND */
     USER_NOT_FOUND(404, "유저를 찾을 수 없습니다."),
     ALREADY_DELETED_POST(404, "이미 삭제된 게시글입니다."),
+    ALREADY_DELETED_COMMENT(404, "이미 삭제된 댓글입니다."),
 
     /* 500 INTERNAL_SERVER_ERROR */
     INTERNAL_SERVER_ERROR(500, "서버 오류가 발생했습니다."),


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] 댓글 수정·삭제 기능 구현

## ✅ 작업 내용
- `CommentUpdateRequestDto`, `CommentDeleteRequestDto` 요청 DTO 추가  
- `CommentService.updateComment()`, `CommentService.deleteComment()` 메서드 구현  
  - 로그인 사용자와 익명 사용자(비회원) 모두 댓글 작성자 본인만 수정·삭제 가능하도록 권한 검증  
  - 익명 비밀번호 검증에 `passwordEncoder.matches()` 적용  
- `CommentController`에 댓글 수정·삭제 엔드포인트 추가  
  - `PATCH /api/posts/{postId}/comments/{commentId}`  
  - `DELETE /api/posts/{postId}/comments/{commentId}`  

## 🔧 변경사항
- **dto/comment/CommentUpdateRequestDto.java**  
- **dto/comment/CommentDeleteRequestDto.java**  
- **service/comment/CommentService.java**  
- **controller/comment/CommentController.java**  

## 📌 관련 이슈
- #48
- closes #53 
